### PR TITLE
fix: only call methods with zero parameters

### DIFF
--- a/src/com/floreysoft/jmte/DefaultModelAdaptor.java
+++ b/src/com/floreysoft/jmte/DefaultModelAdaptor.java
@@ -220,7 +220,8 @@ public class DefaultModelAdaptor implements ModelAdaptor {
             for (Method method : declaredMethods) {
                 if (Modifier.isPublic(method.getModifiers())
                         && (method.getName().equals("get" + suffix) || method
-                        .getName().equals("is" + suffix))) {
+                        .getName().equals("is" + suffix))
+                        && method.getParameterTypes().length == 0) {
                     value = method.invoke(o, (Object[]) null);
                     valueSet = true;
                     member = method;


### PR DESCRIPTION
just a quick fix to ensure JMTE is only calling methods with zero parameters via reflection