### PR TITLE
Added Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8
+
+before_install:
+- export TZ=Europe/Berlin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 JMTE: Java Minimal Template Language
 ====
 
+[![Build Status](https://travis-ci.org/DJCordhose/jmte.svg?branch=master)](https://travis-ci.org/DJCordhose/jmte)
+
 The Java project Minimal Template Engine is meant to fill the gap between simple string formatting with basic Java classes like String.format and complex template solutions like Velocity or StringTemplate.
 
 It is complete but minimal in a sense that you can express everything you need in a template language including 'if' and 'foreach', but nothing else. Because of this it is small, easy to learn and clearly focused. It does not try to solve what Java can do better anyway.


### PR DESCRIPTION
This MR adds a minimalistic Travis-CI support requested by #2.

All tests are running on Oracle JDK 8 and OpenJDK 8. Here is an [example output](https://travis-ci.org/todvora/jmte/builds/308856107).

The only additional step needed to finish the integration is to login to [Travis-CI](https://travis-ci.org) and enable builds for this repository (the badge in readme is already pre-configured for `DJCordhose/jmte` repo). 

Thanks for your library! We are using it through Graylog in [email alert notifications](http://docs.graylog.org/en/2.3/pages/streams/alerts.html#email-alert-notification).