### PR TITLE
feature: added support for object comparison in IF token

### DIFF
--- a/src/com/floreysoft/jmte/token/IfCmpRendererToken.java
+++ b/src/com/floreysoft/jmte/token/IfCmpRendererToken.java
@@ -7,7 +7,7 @@ public class IfCmpRendererToken extends IfCmpToken {
 	private final String rendererName;
 	private final String parameters;
 
-	public IfCmpRendererToken(String expression, String operand, boolean negated, String rendererName, String parameters) {
+	public IfCmpRendererToken(String expression, AbstractToken operand, boolean negated, String rendererName, String parameters) {
 		super(expression, operand, negated);
 		this.rendererName = rendererName;
 		this.parameters = parameters;
@@ -31,7 +31,7 @@ public class IfCmpRendererToken extends IfCmpToken {
         } else {
             string = value == null ? null : value.toString();
         }
-        final boolean condition = getOperand().equals(string);
+        final boolean condition = getOperand(context).equals(string);
         final Object evaluated = negated ? !condition : condition;
         return evaluated;
     }

--- a/src/com/floreysoft/jmte/token/IfCmpToken.java
+++ b/src/com/floreysoft/jmte/token/IfCmpToken.java
@@ -6,27 +6,27 @@ import com.floreysoft.jmte.TemplateContext;
 
 
 public class IfCmpToken extends IfToken {
-	private final String operand;
+	private final AbstractToken operand;
 
-	public IfCmpToken(String expression, String operand, boolean negated) {
+	public IfCmpToken(String expression, AbstractToken operand, boolean negated) {
 		super(expression, negated);
 		this.operand = operand;
 	}
 
-	public IfCmpToken(List<String> segments, String expression, String operand, boolean negated) {
+	public IfCmpToken(List<String> segments, String expression, AbstractToken operand, boolean negated) {
 		super(segments, expression, negated);
 		this.operand = operand;
 	}
 
-	public String getOperand() {
-		return operand == null ? "true" : operand;
+	public String getOperand(TemplateContext context) {
+		return operand == null ? "true" : operand.evaluate(context).toString();
 	}
 
 	@Override
 	public String getText() {
 		if (text == null) {
 			text = String
-					.format(IF + " %s='%s'", getExpression(), getOperand());
+					.format(IF + " %s='%s'", getExpression(), operand == null ? "" : operand.getText());
 		}
 		return text;
 	}
@@ -34,7 +34,7 @@ public class IfCmpToken extends IfToken {
 	@Override
 	public Object evaluate(TemplateContext context) {
 		final Object value = evaluatePlain(context);
-		final boolean condition = value != null && getOperand().equals(value.toString());
+		final boolean condition = value != null && getOperand(context).equals(value.toString());
 		final Object evaluated = negated ? !condition : condition;
 		return evaluated;
 	}

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -240,6 +240,7 @@ public class EngineTest {
 	final static Map<String, Object> DEFAULT_MODEL = new HashMap<String, Object>();
 	static {
 		DEFAULT_MODEL.put("something", "something");
+		DEFAULT_MODEL.put("something2", "something");
 		DEFAULT_MODEL.put("address", "Filbert");
 		DEFAULT_MODEL.put("addressWithSpace", "Filbert Street");
 		DEFAULT_MODEL.put("map", MAP);
@@ -710,12 +711,12 @@ public class EngineTest {
 		assertEquals(DEFAULT_MODEL.get("addressWithSpace"), output);
 	}
 
-    @Test
+    @Test(expected = ParseException.class)
     public void stringEqWithSpace() throws Exception {
-        String output = newEngine().transform(
-                "${if addressWithSpace=Filbert Street}${addressWithSpace}${else}NIX${end}",
-                DEFAULT_MODEL);
-        assertEquals(DEFAULT_MODEL.get("addressWithSpace"), output);
+        Engine newEngine = newEngine();
+        newEngine.setErrorHandler(getTestErrorHandler());
+        newEngine.transform(
+        				"${if addressWithSpace=Filbert Street}${addressWithSpace}${else}NIX${end}", DEFAULT_MODEL);
     }
 
     @Test
@@ -724,6 +725,14 @@ public class EngineTest {
 				"${if address='Filbert'}${address}${else}NIX${end}",
 				DEFAULT_MODEL);
 		assertEquals(DEFAULT_MODEL.get("address"), output);
+	}
+
+	@Test
+	public void stringEqObject() throws Exception {
+		String output = newEngine().transform(
+						"${if something=something2}${something}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(DEFAULT_MODEL.get("something"), output);
 	}
 
     @Test
@@ -737,7 +746,7 @@ public class EngineTest {
 	@Test
 	public void objectNeq() throws Exception {
 		String output = newEngine().transform(
-				"${if !bigDecimal0=0}${bigDecimal0}${else}NIX${end}",
+				"${if !bigDecimal0='0'}${bigDecimal0}${else}NIX${end}",
 				DEFAULT_MODEL);
 		assertEquals("NIX", output);
 	}
@@ -1112,7 +1121,7 @@ public class EngineTest {
 	public void elseInForeach() throws Exception {
 		String output = newEngine()
 				.transform(
-                        "${foreach strings string , }${if string=String1}nada${else}nüscht${end}${end}",
+                        "${foreach strings string , }${if string='String1'}nada${else}nüscht${end}${end}",
                         DEFAULT_MODEL);
 		assertEquals("nada, nüscht, nüscht", output);
 	}
@@ -1653,6 +1662,38 @@ public class EngineTest {
 		String input = "${if address;string()='Filbert'}${address}${else}NIX${end}";
 		String output = newEngine().transform(input, DEFAULT_MODEL);
 		assertEquals("Filbert", output);
+	}
+
+	@Test
+	public void ifEqObjectRendererSample() throws Exception {
+		String output = newEngine().transform(
+						"${if something;string=something2;string}${something}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(DEFAULT_MODEL.get("something"), output);
+	}
+
+	@Test
+	public void ifEqObjectRendererBracketsSample1() throws Exception {
+		String output = newEngine().transform(
+						"${if something;string()=something2;string}${something}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(DEFAULT_MODEL.get("something"), output);
+	}
+
+	@Test
+	public void ifEqObjectRendererBracketsSample2() throws Exception {
+		String output = newEngine().transform(
+						"${if something;string=something2;string()}${something}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(DEFAULT_MODEL.get("something"), output);
+	}
+
+	@Test
+	public void ifEqObjectRendererBracketsSample3() throws Exception {
+		String output = newEngine().transform(
+						"${if something;string()=something2;string()}${something}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(DEFAULT_MODEL.get("something"), output);
 	}
 
 	@Test

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -760,6 +760,30 @@ public class EngineTest {
 	}
 
 	@Test
+	public void objectEqObject() throws Exception {
+		String output = newEngine().transform(
+						"${if bean.property2=bean.property2}${bean.property2}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(BEAN.property2.toString(), output);
+	}
+
+	@Test
+	public void objectEqObject2() throws Exception {
+		String output = newEngine().transform(
+						"${if bean.property2=bean.property1}${bean.property2}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals("NIX", output);
+	}
+
+	@Test
+	public void objectNeqObject() throws Exception {
+		String output = newEngine().transform(
+						"${if !bean.property2=bean.property1}${bean.property2}${else}NIX${end}",
+						DEFAULT_MODEL);
+		assertEquals(BEAN.property2.toString(), output);
+	}
+
+	@Test
 	public void stringEqNotElse() throws Exception {
 		String output = newEngine().transform(
                 "${if !address='Filbert'}${address}${else}NIX${end}",


### PR DESCRIPTION
I've enhanced the IfCmpToken to support comparison against another object from the model (inclusive support for renderers on both sides) with a little drawback (which is OK in my eyes). A comparison against a string literal _without_ quotes is no more possible (but to be honest, if someone wants to compare against a string literal, putting that into quotes should be obligatory...)

For this drawback I needed to adopt a few of your unit tests which used string comparisons without quotes (and one which is now "unsupported" due to the new logic)