### PR TITLE
Engine concurrency issue repro added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.4.0</version>
+      <scope>test</scope>
+    </dependency>
 	<dependency>
 		<groupId>org.ow2.asm</groupId>
 		<artifactId>asm</artifactId>

--- a/src/com/floreysoft/jmte/token/Lexer.java
+++ b/src/com/floreysoft/jmte/token/Lexer.java
@@ -28,7 +28,7 @@ public class Lexer {
 	private String unescapeAccess(List<? extends Object> arr,int index){
 		String val = access(arr,index);
 		if (val!=null && val.trim().length()>0){
-			val = Util.NO_QUOTE_MINI_PARSER.unescape(val); 
+			val = Util.createNoQuoteMiniParser().unescape(val);
 		}
 		return val;
 	}
@@ -176,7 +176,7 @@ public class Lexer {
 
 				String separator = input.substring(separatorBegin);
 				if (separator !=null){
-					separator = Util.NO_QUOTE_MINI_PARSER.unescape(separator);
+					separator = Util.createNoQuoteMiniParser().unescape(separator);
 				}
                 final ForEachToken forEachToken = new ForEachToken(objectExpression, varName, separator
                         .length() != 0 ? separator : null);

--- a/src/com/floreysoft/jmte/token/TokenStream.java
+++ b/src/com/floreysoft/jmte/token/TokenStream.java
@@ -36,7 +36,7 @@ public class TokenStream {
 			int plainTextLengthBeforeNextToken = startEndPair.start
 					- splitStart.length() - offset;
 			if (plainTextLengthBeforeNextToken != 0) {
-				AbstractToken token = new PlainTextToken(Util.NO_QUOTE_MINI_PARSER.unescape(new String(inputChars,
+				AbstractToken token = new PlainTextToken(Util.createNoQuoteMiniParser().unescape(new String(inputChars,
 						offset, plainTextLengthBeforeNextToken)));
 				token.setTokenIndex(index++);
 				tokens.add(token);
@@ -59,7 +59,7 @@ public class TokenStream {
 		// chunk indeed)
 		int remainingChars = input.length() - offset;
 		if (remainingChars != 0) {
-			AbstractToken token = new PlainTextToken(Util.NO_QUOTE_MINI_PARSER.unescape(new String(inputChars,
+			AbstractToken token = new PlainTextToken(Util.createNoQuoteMiniParser().unescape(new String(inputChars,
 					offset, remainingChars)));
 			token.setTokenIndex(index++);
 			tokens.add(token);

--- a/src/com/floreysoft/jmte/util/Util.java
+++ b/src/com/floreysoft/jmte/util/Util.java
@@ -40,6 +40,16 @@ public class Util {
 			.fullRawInstance();
 	public final static MiniParser NO_QUOTE_MINI_PARSER = new MiniParser(
 			MiniParser.DEFAULT_ESCAPE_CHAR, (char) -1, false, false, false);
+
+	public static MiniParser createNoQuoteMiniParser() {
+		return NO_QUOTE_MINI_PARSER;
+		/*
+		 * If we return a new instance here, then EngineTest.testConcurrentAccessToJmteEngine passes.
+ 		 */
+//		return new MiniParser(
+//				MiniParser.DEFAULT_ESCAPE_CHAR, (char) -1, false, false, false);
+	}
+
 	public final static MiniParser RAW_OUTPUT_MINI_PARSER = MiniParser
 			.rawOutputInstance();
 

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -1914,4 +1914,18 @@ public class EngineTest {
 
 	}
 
+	/**
+	 * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
+	 */
+	@org.testng.annotations.Test(threadPoolSize = 10, invocationCount = 10000, timeOut = 10000)
+	public void testConcurrentAccessToJmteEngine() {
+		String template = "/blah/\\\\.html";
+		String expected = "/blah/\\.html";
+		Engine engine = new Engine();
+		String result =  engine.transform(template, new HashMap<>());
+		assertEquals(expected, result);
+	}
+
+
+
 }


### PR DESCRIPTION
The idea of this PR is to point at a concurrency issue (see EngineTest):

The Engine uses a TokenStream which in turn uses a single instance of the MiniParser. Access on the public method of the Engine is synchronized but if multiple instances of the Engine are created in a multithreaded environment then they end up using a single instance of the MiniParser. The MiniParser is not thread safe, hence we can see issues in rare cases.


<img width="1520" alt="jmte" src="https://user-images.githubusercontent.com/30789476/142372650-2637dcb0-7676-4c0e-a698-68e9bcde3dbf.png">
