### PR TITLE
ChainedNamedRenderer, UpperCaseNamedRenderer and LowerCaseNamedRenderer

### DIFF
--- a/src/com/floreysoft/jmte/extended/ChainedNamedRenderer.java
+++ b/src/com/floreysoft/jmte/extended/ChainedNamedRenderer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012 - 2020 Manuel Laggner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.floreysoft.jmte.extended;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+import com.floreysoft.jmte.util.Util;
+
+import java.util.*;
+
+/**
+ * This {@link NamedRenderer} can be used to chain other {@link NamedRenderer}s.
+ * <p>
+ * This renderer is able to pass the rendered {@link String} across several different
+ * {@link NamedRenderer}s. All renderers are able to use their specific format parameters -
+ * they just need to be separated by a semicolon (;). To make this work, you need to register
+ * this renderer <b>after</b> all other renderer in the {@link com.floreysoft.jmte.Engine}. E.g.:
+ * <pre>engine.registerNamedRenderer(new ChainedNamedRenderer(engine.getAllNamedRenderers()));</pre>
+ * </p>
+ * <p/>
+ * <p>
+ * Example: <pre>${token;chain(renderer1(options1);renderer2)}</pre>
+ * </p>
+ */
+public class ChainedNamedRenderer implements NamedRenderer {
+
+    private final Map<String, NamedRenderer> namedRenderers;
+
+    public ChainedNamedRenderer(Collection<NamedRenderer> namedRenderers) {
+        this.namedRenderers = new HashMap<>();
+        namedRenderers.forEach(namedRenderer -> this.namedRenderers.put(namedRenderer.getName(), namedRenderer));
+    }
+
+    @Override
+    public String render(Object o, String format, Locale locale, Map<String, Object> model) {
+        Object result = o;
+
+        List<String> subRenderers = Util.RAW_OUTPUT_MINI_PARSER.split(format, ';', Integer.MAX_VALUE);
+
+        for (String subRenderer : subRenderers) {
+            List<String> strings = Util.MINI_PARSER.greedyScan(subRenderer, "(", ")");
+
+            String rendererName = getSafe(strings, 0);
+            String rendererParams = getSafe(strings, 1);
+
+            if (rendererName == null || rendererName.isEmpty()) {
+                continue;
+            }
+
+            NamedRenderer namedRenderer = namedRenderers.get(rendererName);
+            if (namedRenderer != null) {
+                result = namedRenderer.render(result, rendererParams, locale, model);
+            }
+        }
+
+        return String.valueOf(result);
+    }
+
+    private String getSafe(List<String> list, int index) {
+        if (index < list.size()) {
+            return list.get(index);
+        }
+        return "";
+    }
+
+    @Override
+    public String getName() {
+        return "chain";
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class[0];
+    }
+}

--- a/src/com/floreysoft/jmte/extended/LowerCaseNamedRenderer.java
+++ b/src/com/floreysoft/jmte/extended/LowerCaseNamedRenderer.java
@@ -1,0 +1,40 @@
+package com.floreysoft.jmte.extended;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Lower case {@link NamedRenderer}.
+ * <p>
+ * This renderer renders the given {@link String} into lower case
+ * </p>
+ */
+public class LowerCaseNamedRenderer implements NamedRenderer {
+
+    @Override
+    public String render(Object o, String s, Locale locale, Map<String, Object> map) {
+        if (o == null) {
+            return "";
+        }
+
+        return o.toString().toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public String getName() {
+        return "lowercase";
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class[]{String.class};
+    }
+}

--- a/src/com/floreysoft/jmte/extended/UpperCaseNamedRenderer.java
+++ b/src/com/floreysoft/jmte/extended/UpperCaseNamedRenderer.java
@@ -1,0 +1,40 @@
+package com.floreysoft.jmte.extended;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Upper case {@link NamedRenderer}.
+ * <p>
+ * This renderer renders the given {@link String} into UPPER CASE
+ * </p>
+ */
+public class UpperCaseNamedRenderer implements NamedRenderer {
+
+    @Override
+    public String render(Object o, String s, Locale locale, Map<String, Object> map) {
+        if (o == null) {
+            return "";
+        }
+
+        return o.toString().toUpperCase(Locale.ROOT);
+    }
+
+    @Override
+    public String getName() {
+        return "uppercase";
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class[]{String.class};
+    }
+}

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -9,6 +9,9 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.Callable;
 
+import com.floreysoft.jmte.extended.ChainedNamedRenderer;
+import com.floreysoft.jmte.extended.LowerCaseNamedRenderer;
+import com.floreysoft.jmte.extended.UpperCaseNamedRenderer;
 import com.floreysoft.jmte.message.*;
 import com.floreysoft.jmte.renderer.NullRenderer;
 import com.floreysoft.jmte.renderer.OptionRenderFormatInfo;
@@ -93,7 +96,9 @@ public class EngineTest {
 	});
 	final Engine ENGINE_WITH_NAMED_RENDERERS = ENGINE_WITH_CUSTOM_RENDERERS
 			.registerNamedRenderer(new NamedDateRenderer())
-			.registerNamedRenderer(new NamedStringRenderer());
+			.registerNamedRenderer(new NamedStringRenderer())
+			.registerNamedRenderer(new UpperCaseNamedRenderer())
+			.registerNamedRenderer(new LowerCaseNamedRenderer());
 
 	private static final MyBean MyBean1 = new MyBean("1.1", "1.2");
 	private static final MyBean MyBean2 = new MyBean("2.1", "2.2");
@@ -1240,6 +1245,32 @@ public class EngineTest {
 	}
 
 	@Test
+	public void namedUpperCaseRenderer() throws Exception {
+		String output = ENGINE_WITH_NAMED_RENDERERS
+				.transform( "${address;uppercase}", DEFAULT_MODEL);
+		assertEquals("FILBERT", output);
+	}
+
+	@Test
+	public void namedLowerCaseRenderer() throws Exception {
+		String output = ENGINE_WITH_NAMED_RENDERERS
+				.transform( "${address;lowercase}", DEFAULT_MODEL);
+		assertEquals("filbert", output);
+	}
+
+	@Test
+	public void namedChainedRenderer() throws Exception {
+		Engine engine = new Engine();
+		engine.registerNamedRenderer(new UpperCaseNamedRenderer());
+		engine.registerNamedRenderer(new NamedStringRenderer());
+		engine.registerNamedRenderer(new ChainedNamedRenderer(engine.getAllNamedRenderers()));
+
+		String output = engine
+				.transform( "${address;chain(string(foo);uppercase)}", DEFAULT_MODEL);
+		assertEquals("STRING=FILBERT(FOO)", output);
+	}
+
+	@Test
 	public void namedRendererHasPrecedence() throws Exception {
 		final Engine engine = newEngine();
 		engine.registerRenderer(String.class, new Renderer<String>() {
@@ -1316,7 +1347,7 @@ public class EngineTest {
 	private String clearTimezone(String timeString) {
 		return timeString.replace("MEZ", "").replace("CET", "");
 	}
-	
+
 	@Test
 	public void callable() throws Exception {
 		Callable<Date> date = new Callable<Date>() {
@@ -1463,15 +1494,15 @@ public class EngineTest {
 				model);
 		assertEquals("back\\slash for all: Hello \\ world!", output);
 	}
-	
+
 	@Test
 	public void forachIterator() throws Exception {
 		String actual = newEngine().transform("${foreach list i}${_it.property1}${end}", DEFAULT_MODEL);
 		String output = newEngine().transform("${foreach list i}${i.property1}${end}", DEFAULT_MODEL);
 		assertEquals(output, actual);
 	}
-	
-	@Test		
+
+	@Test
 	public void forachIteratorNested() throws Exception {
 		String actual = newEngine()
 				.transform(
@@ -1483,7 +1514,7 @@ public class EngineTest {
 						DEFAULT_MODEL);
 		assertEquals(output, actual);
 	}
-	
+
 	@Test
 	public void forachIndex() throws Exception {
 		Map<String, Object> model = new HashMap<String, Object>();
@@ -1494,7 +1525,7 @@ public class EngineTest {
 		String expected = "1. item A\n" + "2. item B\n" + "3. item C";
 		assertEquals(expected, actual);
 	}
-	
+
 	@Test
 	public void nestedForachIndex() throws Exception {
 		Map<String, Object> model = new HashMap<String, Object>();
@@ -1509,7 +1540,7 @@ public class EngineTest {
 
 
 	private static NamedRenderer indexRenderer = new NamedRenderer() {
-		
+
 		@Override
 		public String render(Object o, String format, Locale locale, Map<String,Object> model) {
 			if (format != null && format.length() > 0 && Character.isLetter(format.charAt(0))) {
@@ -1524,20 +1555,20 @@ public class EngineTest {
 					// do nothing, simply fall back to default formatting
 				}
 			}
-			// suppose we have a number a index, use it with a bit of formatting 
+			// suppose we have a number a index, use it with a bit of formatting
 			return "(" + o.toString() + ")";
 		}
-		
+
 		@Override
 		public Class<?>[] getSupportedClasses() {
 			return new Class[]{String.class};
 		}
-		
+
 		@Override
 		public String getName() {
 			return "index";
 		}
-		
+
 		@Override
 		public RenderFormatInfo getFormatInfo() {
 			return null;
@@ -1553,7 +1584,7 @@ public class EngineTest {
 		// sample renderer that can do number and letter bullet points
 		// can easily be extended to any other format
 		engine.registerNamedRenderer(indexRenderer);
-		
+
 		String actual = engine.transform("${foreach array item \n}${index_item;index} ${item}${end}", model);
 		String expected = "(1) item A\n" + "(2) item B\n" + "(3) item C";
 		assertEquals(expected, actual);
@@ -1569,7 +1600,7 @@ public class EngineTest {
 		// sample renderer that can do number and letter bullet points
 		// can easily be extended to any other format
 		engine.registerNamedRenderer(indexRenderer);
-		
+
 		String actual = engine.transform("${foreach array item \n}${index_item;index} ${item}\n${foreach array2 inner \n}${index_inner;index(a)} ${inner}${end}${end}", model);
 		String expected = "(1) outer#1\n" + "a. inner#1\n" +"b. inner#2\n" + "(2) outer#2\n"+ "a. inner#1\n" +"b. inner#2";
 		assertEquals(expected, actual);
@@ -1591,7 +1622,7 @@ public class EngineTest {
 		String expected = "<input type='text' name='title' value=whatever/>";
 		assertEquals(expected, actual);
 	}
-	
+
 	@Test
 	public void xmlEncoder() throws Exception {
 		Engine engine = newEngine();


### PR DESCRIPTION
this PR adds three common named renderers which can be handy for all JMTE users:

UpperCaseNamedRenderer: renders the given string into UPPER case
LowerCaseNamedRenderer: renders the given string into lower case
ChainedNamedRenderer: this renderer allows to chain several named renderers in a row:

>  This renderer is able to pass the rendered String across several different NamedRenderers. All renderers are able to use their specific format parameters - they just need to be separated by a semicolon (;). To make this work, you need to register this renderer **after** all other renderers in the Engine. 
> E.g. `engine.registerNamedRenderer(new ChainedNamedRenderer(engine.getAllNamedRenderers()));`
>
> Example: `${token;chain(renderer1(options1);renderer2)}`