### PR TITLE
fix: also handle AnnotationTokens in IF/ELSE paths

### DIFF
--- a/src/com/floreysoft/jmte/template/InterpretedTemplate.java
+++ b/src/com/floreysoft/jmte/template/InterpretedTemplate.java
@@ -10,6 +10,7 @@ import com.floreysoft.jmte.ScopedMap;
 import com.floreysoft.jmte.TemplateContext;
 import com.floreysoft.jmte.message.ErrorEntry;
 import com.floreysoft.jmte.message.JournalingErrorHandler;
+import com.floreysoft.jmte.token.AnnotationToken;
 import com.floreysoft.jmte.token.ElseToken;
 import com.floreysoft.jmte.token.EndToken;
 import com.floreysoft.jmte.token.ExpressionToken;
@@ -275,7 +276,7 @@ public class InterpretedTemplate extends AbstractTemplate {
 			if (!skip) {
 				this.context.engine.getOutputAppender().append(this.getOutput(), token.getText(), token);
 			}
-		} else if (token instanceof StringToken) {
+		} else if (token instanceof StringToken || token instanceof AnnotationToken) {
 			tokenStream.consume();
 			if (!skip) {
 				String expanded = (String) token.evaluate(context);

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -1497,6 +1497,26 @@ public class EngineTest {
 	}
 
 	@Test
+	public void annotationProcessorWithCondition() throws Exception {
+		String input = "${if address='Filbert'}${address}${else}${@sample argument}${end}";
+		Engine engine = newEngine();
+		engine.registerAnnotationProcessor(new AnnotationProcessor<String>() {
+
+			@Override
+			public String eval(AnnotationToken token, TemplateContext context) {
+				return token.getArguments();
+			}
+
+			@Override
+			public String getType() {
+				return "sample";
+			}
+		});
+		String output = engine.transform(input, DEFAULT_MODEL);
+		assertEquals("Filbert", output);
+	}
+
+	@Test
 	public void backslashInData() throws Exception {
 		Map<String, Object> model = new HashMap<String, Object>();
 		model.put("str", "Hello \\ world!");


### PR DESCRIPTION
If you put an AnnotationToken inside an if/else construct, die token will always be added to the output (the condition is not respected).

This is due to the missing handling of the AnnotationToken in the InterpretedTemplate.

With this commit I've added a new unit test showing the problem and the fix into the InterpretedTemplate