### PR TITLE
Fix `${if condition = " }` `StringIndexOutOfBoundsException`

### DIFF
--- a/src/com/floreysoft/jmte/token/IfCmpToken.java
+++ b/src/com/floreysoft/jmte/token/IfCmpToken.java
@@ -39,4 +39,18 @@ public class IfCmpToken extends IfToken {
 		return evaluated;
 	}
 
+    @Override public void setColumn(char[] buffer, int start, int end) {
+        super.setColumn(buffer, start, end);
+        if (operand != null) {
+            operand.setColumn(buffer, start + operand.getColumn() - 1, end);
+        }
+    }
+
+    @Override public void setLine(char[] buffer, int start, int end) {
+        super.setLine(buffer, start, end);
+        if (operand != null) {
+            operand.setLine(buffer, start + operand.getLine() - 1, end);
+        }
+    }
+
 }

--- a/src/com/floreysoft/jmte/token/Lexer.java
+++ b/src/com/floreysoft/jmte/token/Lexer.java
@@ -98,23 +98,11 @@ public class Lexer {
                     final String complexVariable;
 
                     if (hasCmp) {
-                        String operand = completeIfExpression.substring(posEq + 1);
-                        // heuristic: when there is leading or trailing space and after that a quote begins,
-						// it must be ignorable white space
-						if (isQuoted(operand.trim())) {
-							operand = operand.trim();
-						}
-                        // remove optional quotations
-                        if (isQuoted(operand)) {
-                        	innerToken = new PlainTextToken(operand.substring(1, operand.length() - 1));
-                        } else {
-													// no string operand since there are no quotes -> resolve this to be a resolved expression
-													innerToken = innerNextToken(operand);
-												}
                         complexVariable = completeIfExpression.substring(0, posEq).trim();
+                        innerToken = ifCmpOperand(untrimmedInput, completeIfExpression.substring(posEq + 1));
                     } else {
                         complexVariable = completeIfExpression;
-												innerToken = null;
+                        innerToken = null;
                     }
                     // if there is a semicolon before an eq, this must be a renderer applied to the variable
                     // like:
@@ -253,8 +241,37 @@ public class Lexer {
 
 	}
 
-	private static boolean isQuoted(String operand) {
-		return operand.startsWith("'") || operand.startsWith("\"");
+    private AbstractToken ifCmpOperand(String untrimmedInput, String untrimmedOperand) {
+        String operand = trimQuotedOperand(untrimmedOperand);
+        if (isQuoted(operand)) {
+            return new PlainTextToken(operand.substring(1, operand.length() - 1));
+        }
+
+        // no string operand since there are no quotes -> resolve this to be a resolved expression
+        final AbstractToken innerToken = innerNextToken(operand);
+        char[] buffer = untrimmedInput.toCharArray();
+        int index = untrimmedInput.length() - operand.length();
+        innerToken.setText(operand);
+        innerToken.setLine(buffer, index, untrimmedInput.length());
+        innerToken.setColumn(buffer, index, untrimmedInput.length());
+
+        return innerToken;
+    }
+
+    private String trimQuotedOperand(String untrimmedOperand) {
+        // heuristic: when there is leading or trailing space and after that a quote begins,
+        // it must be ignorable white space
+        String trimmedOperand = untrimmedOperand.trim();
+        if (isQuoted(trimmedOperand)) {
+            return trimmedOperand;
+        }
+        return untrimmedOperand;
+    }
+
+    private static boolean isQuoted(String operand) {
+        return operand.length() >= 2
+                && (operand.startsWith("'") || operand.startsWith("\""))
+                && operand.endsWith(operand.substring(0, 1));
 	}
 
 }

--- a/test/com/floreysoft/jmte/EngineTest.java
+++ b/test/com/floreysoft/jmte/EngineTest.java
@@ -3,7 +3,6 @@ package com.floreysoft.jmte;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.*;
@@ -16,7 +15,6 @@ import com.floreysoft.jmte.message.*;
 import com.floreysoft.jmte.renderer.NullRenderer;
 import com.floreysoft.jmte.renderer.OptionRenderFormatInfo;
 import com.floreysoft.jmte.renderer.SimpleNamedRenderer;
-import com.floreysoft.jmte.template.ErrorReportingOutputAppender;
 import com.floreysoft.jmte.token.InvalidToken;
 import com.floreysoft.jmte.token.Lexer;
 import com.floreysoft.jmte.util.StartEndPair;
@@ -1880,6 +1878,19 @@ public class EngineTest {
 		Token token = lexer.nextToken(line.toCharArray(), 2, 4);
 		assertTrue(token instanceof InvalidToken);
 	}
+
+    @Test
+    public void unclosedIfConditionStringIsInvalid() throws Exception {
+        String line = "test\ntest${ if something = \" }";
+        final Engine engine = newEngine();
+        JournalingErrorHandler errorHandler = new JournalingErrorHandler();
+        engine.setErrorHandler(errorHandler);
+
+        engine.transform(line, DEFAULT_MODEL);
+
+        ErrorEntry errorEntry = errorHandler.entries.get(0);
+        assertEquals("Error while parsing ' \" ' at location (2:22): Invalid expression!", errorEntry.formattedMessage.format());
+    }
 
 	@Test
 	public void extract() throws Exception {


### PR DESCRIPTION
When the if condition string consists of a single quote `${if condition = " }`, a `StringIndexOutOfBoundsException` is thrown:

    java.lang.StringIndexOutOfBoundsException: begin 1, end 0, length 1
	    at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4601)
	    at java.base/java.lang.String.substring(String.java:2704)
	    at com.floreysoft.jmte.token.Lexer.innerNextToken(Lexer.java:109)
	    at com.floreysoft.jmte.token.Lexer.nextToken(Lexer.java:21)

Also this PR adds text, line, and column to the if cmp operand, so that the error message is better:

`Error while parsing ' " ' at location (2:22): Invalid expression!`